### PR TITLE
Add OutlineButton & guard round advance

### DIFF
--- a/client/src/components/CaptionBox.jsx
+++ b/client/src/components/CaptionBox.jsx
@@ -1,18 +1,36 @@
 // components/CaptionBox.jsx
 import React from 'react';
+import { Crown, BookOpenText } from 'lucide-react';
+import { socket } from '../socket';
+import OutlineCard from './OutlineCard';
 
 function CaptionBox({ caption, readerId, round, maxRounds }) {
   if (!caption) return null;
 
+  const isReader = socket.id === readerId;
+
   return (
-    <div className="mt-8 bg-yellow-100 border border-yellow-400 p-4 rounded shadow text-center">
-      <h3 className="text-lg font-bold text-yellow-700">📝 Caption of the Round</h3>
-      <p className="text-xl italic text-black  mt-2">"{caption}"</p>
-      <p className="text-sm text-gray-600 mt-1">Reader ID: {readerId}</p>
-      <p className="text-sm text-gray-800 font-semibold mt-2">
-        Round {round} of {maxRounds}
+    <OutlineCard className="mt-8 px-6 py-4 md:px-8 md:py-5 text-center">
+      <h3
+        className="flex justify-center items-center gap-2 font-heading text-primary text-2xl mb-3"
+        role="heading"
+        aria-level="3"
+      >
+        <BookOpenText size={20} /> Caption of the Round
+      </h3>
+
+      <p className="italic text-lg md:text-xl mb-2 text-base-content" aria-live="polite">
+        {caption}
       </p>
-    </div>
+
+      {isReader && (
+        <p className="flex items-center justify-center gap-1 text-accent-400 font-medium mb-1">
+          <Crown size={16} className="text-accent-400" /> You are the reader
+        </p>
+      )}
+
+      <p className="font-bold">Round {round} of {maxRounds}</p>
+    </OutlineCard>
   );
 }
 

--- a/client/src/components/EndGameButton.jsx
+++ b/client/src/components/EndGameButton.jsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { Ban } from 'lucide-react';
 import { socket } from '../socket';
+import OutlineButton from './OutlineButton';
 
-function EndGameButton({ room }) {
+function EndGameButton({ room, className = '' }) {
   const captionReaderId = useSelector((state) => state.game.captionReaderId);
   const isReader = socket.id === captionReaderId;
 
   if (!isReader) return null;
 
   return (
-    <button
+    <OutlineButton
       onClick={() => socket.emit('force_end_game', { room })}
-      className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded mt-4"
-    >
-      🛑 End Game
-    </button>
+      label="End Game"
+      icon={<Ban className="w-5 h-5" />}
+      className={className}
+    />
   );
 }
 

--- a/client/src/components/JoinRoomForm.jsx
+++ b/client/src/components/JoinRoomForm.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
+import { Gamepad } from 'lucide-react';
 import { socket } from '../socket';
 import { setMyName, setRoom as setRoomRedux } from '../features/game/gameSlice';
+import OutlineButton from './OutlineButton';
 
 const SOFT_RADIUS = 120;
 const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
@@ -104,12 +106,12 @@ export default function JoinRoomForm({ onNameChange, onRoomJoined, faceRef }) {
       </div>
 
       {/* ----- Row 2 ----- */}
-      <button
-        className="w-full py-2 rounded bg-purple-600 hover:bg-purple-700 text-white font-semibold"
+      <OutlineButton
+        className="w-full"
         onClick={handleJoin}
-      >
-        Join Room 🎮
-      </button>
+        label="Join Room"
+        icon={<Gamepad className="w-5 h-5" />}
+      />
     </div>
   );
 }

--- a/client/src/components/OutlineButton.jsx
+++ b/client/src/components/OutlineButton.jsx
@@ -6,7 +6,7 @@ export default function OutlineButton({ label, icon = null, onClick, disabled = 
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`border border-primary text-primary hover:bg-primary hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition rounded-full px-6 py-2 flex items-center justify-center gap-2 ${className}`}
+      className={`border border-primary text-primary hover:bg-primary hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition rounded-none px-6 py-2 flex items-center justify-center gap-2 ${className}`}
     >
       {icon}
       <span>{label}</span>

--- a/client/src/components/OutlineButton.jsx
+++ b/client/src/components/OutlineButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function OutlineButton({ label, icon = null, onClick, disabled = false, className = '' }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`border border-primary text-primary hover:bg-primary hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition rounded-full px-6 py-2 flex items-center justify-center gap-2 ${className}`}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/client/src/components/OutlineCard.jsx
+++ b/client/src/components/OutlineCard.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function OutlineCard({ children, className = '' }) {
+  return (
+    <div
+      className={`border border-primary/80 bg-primary/5 rounded-lg shadow-md hover:shadow-[0_0_8px_theme(colors.primary.DEFAULT)/0.8] transition px-6 py-4 md:px-8 md:py-5 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;700&family=Inter:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/client/src/pages/GameOverScreen.jsx
+++ b/client/src/pages/GameOverScreen.jsx
@@ -2,6 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { socket } from '../socket';
 import Scoreboard from '../components/Scoreboard';
 import AnimationController from '../components/AnimationController';
+import OutlineButton from '../components/OutlineButton';
 
 function GameOverScreen() {
   const winner = useSelector((state) => state.game.winner);
@@ -32,12 +33,12 @@ function GameOverScreen() {
 
       <Scoreboard players={players} scores={scores} />
 
-      <button
+      <OutlineButton
+        className="mt-6"
         onClick={handlePlayAgain}
-        className="mt-6 bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded"
-      >
-        🔁 Play Again
-      </button>
+        label="Play Again"
+        icon={<span>🔁</span>}
+      />
 
       <p className="mt-4 text-sm text-gray-500 italic">
         (Sends everyone back to the Join Room form)

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -2,7 +2,8 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { socket } from '../socket'
-import { Gamepad } from 'lucide-react'
+import { Gamepad, Users2 } from 'lucide-react'
+import OutlineButton from '../components/OutlineButton'
 
 import PlayerList   from '../components/PlayerList'
 import CaptionBox   from '../components/CaptionBox'
@@ -24,34 +25,39 @@ export default function Lobby() {
 
   return (
     <div className="flex-1 flex justify-center items-start px-4 py-8">
-      <div className="card bg-neutral p-8 rounded-2xl shadow-2xl w-full max-w-md text-center mx-auto">
-        <h2 className="text-4xl font-bold mb-6 neon-secondary">
+      <div className="card bg-gradient-to-br from-neutral-800 to-neutral-900 p-10 rounded-2xl shadow-xl ring-1 ring-neutral-700 w-full max-w-lg sm:max-w-xl text-center mx-auto">
+        <h2
+          className="text-5xl font-extrabold neon-primary mb-6"
+          style={{ textShadow: '0 0 8px rgba(255,100,200,0.6)' }}
+        >
           LOBBY
         </h2>
 
-        <p className="mt-2 text-sm text-base-content/70 italic">
-          You are: <span className="font-semibold">{myName}</span>
-        </p>
+        <div className="flex flex-col sm:flex-row gap-4 mt-6">
+          {isHost && (
+            <OutlineButton
+              onClick={handleStart}
+              label="Start Round"
+              icon={<Gamepad className="w-5 h-5" />}
+              className="flex-1"
+            />
+          )}
+          <EndGameButton room={room} className="flex-1" />
+        </div>
 
-        {isHost && (
-          <button
-            onClick={handleStart}
-            className="btn btn-secondary btn-block mt-4 mb-2"
-          >
-            <Gamepad className="inline-block mr-2" /> Start Round
-          </button>
-        )}
-
-        <EndGameButton room={room} />
-
-        <div className="mt-6 space-y-4">
-          <PlayerList players={players} />
-          <CaptionBox
-            caption={currentCaption}
-            readerId={captionReaderId}
-            round={round}
-            maxRounds={maxRounds}
-          />
+        <div className="mt-6 space-y-6">
+          <h3 className="text-xl font-semibold flex items-center gap-2">
+            <Users2 className="w-6 h-6 neon-secondary" /> Players in Room
+          </h3>
+          <div className="space-y-6">
+            <PlayerList players={players} />
+            <CaptionBox
+              caption={currentCaption}
+              readerId={captionReaderId}
+              round={round}
+              maxRounds={maxRounds}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/pages/MemePhase.jsx
+++ b/client/src/pages/MemePhase.jsx
@@ -25,19 +25,6 @@ function MemePhase() {
         maxRounds={maxRounds}
       />
 
-      {myName && (
-        <p className="mt-2 text-sm text-gray-600 italic">
-          You are: <span className="font-semibold">{myName}</span>
-        </p>
-      )}
-
-      {socket.id === captionReaderId && (
-        <p className="mt-2 text-yellow-600 italic font-medium">
-          👑 You are the reader this round. Others will choose memes.
-        </p>
-      )}
-
-
       <MemeHand />
     </div>
   );

--- a/client/src/pages/RevealPhase.jsx
+++ b/client/src/pages/RevealPhase.jsx
@@ -5,6 +5,7 @@ import EndGameButton from '../components/EndGameButton';
 import CaptionBox from '../components/CaptionBox';
 import { socket } from '../socket';
 import AnimationController from '../components/AnimationController';
+import OutlineButton from '../components/OutlineButton';
 
 function RevealPhase() {
   const {
@@ -16,9 +17,15 @@ function RevealPhase() {
     room,
   } = useSelector(state => state.game);
 
-  const isReader = socket.id === captionReaderId;
+  const myId = socket.id;
+  const isReader = myId === captionReaderId;
+  const canAdvance = !isReader || !!winner;
 
   const handleNextRound = () => {
+    if (!canAdvance) {
+      alert('Select a meme before advancing!');
+      return;
+    }
     if (room) {
       socket.emit('start_round', { room });
     }
@@ -48,12 +55,12 @@ function RevealPhase() {
 
           {/* 🔁 Only show Next Round if not at final round */}
           {round < maxRounds && (
-            <button
+            <OutlineButton
               onClick={handleNextRound}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded"
-            >
-              🔁 Next Round
-            </button>
+              disabled={!canAdvance}
+              label="Next Round"
+              icon={<span>🔁</span>}
+            />
           )}
         </div>
       )}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,6 +8,14 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
     "./src/index.css",
   ],
+  theme: {
+    extend: {
+      fontFamily: {
+        heading: ['"Chakra Petch"', 'sans-serif'],
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
+  },
   plugins: [daisyui],
   daisyui: {
     themes: [


### PR DESCRIPTION
## Summary
- create reusable OutlineButton with primary border style
- refactor EndGameButton and JoinRoomForm to use OutlineButton
- polish Lobby, RevealPhase, GameOverScreen buttons
- prevent caption reader from starting next round until a winner is selected

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_684288668b4883319a10f394444e407a